### PR TITLE
Implement escape sequences for string literals

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,6 +1,8 @@
 package lexer
 
 import (
+	"strings"
+
 	"github.com/vknabel/blush/registry"
 	"github.com/vknabel/blush/token"
 )
@@ -151,14 +153,45 @@ func (l *Lexer) NextToken() token.Token {
 }
 
 func (l *Lexer) parseString() string {
-	position := l.currPos + 1
+	var out strings.Builder
+	escaped := false
 	for {
 		l.advance()
-		if l.ch == '"' || l.ch == 0 {
+		ch := l.ch
+
+		if ch == 0 {
 			break
 		}
+
+		if escaped {
+			switch ch {
+			case 'n':
+				out.WriteByte('\n')
+			case '\\':
+				out.WriteByte('\\')
+			case '"':
+				out.WriteByte('"')
+			default:
+				out.WriteByte('\\')
+				out.WriteByte(ch)
+			}
+			escaped = false
+			continue
+		}
+
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+
+		if ch == '"' {
+			break
+		}
+
+		out.WriteByte(ch)
 	}
-	return l.input[position:l.currPos]
+
+	return out.String()
 }
 
 func (l *Lexer) parseChar() (string, bool) {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -505,6 +505,39 @@ func TestAllTokens(t *testing.T) {
 			},
 		},
 		{
+			name:  "string escaped newline",
+			input: "\"\\n\"",
+			expected: []struct {
+				expectedType    token.TokenType
+				expectedLiteral string
+			}{
+				{token.STRING, "\n"},
+				{token.EOF, ""},
+			},
+		},
+		{
+			name:  "string escaped quote",
+			input: "\"\\\"\"",
+			expected: []struct {
+				expectedType    token.TokenType
+				expectedLiteral string
+			}{
+				{token.STRING, "\""},
+				{token.EOF, ""},
+			},
+		},
+		{
+			name:  "string escaped backslash",
+			input: "\"\\\\\"",
+			expected: []struct {
+				expectedType    token.TokenType
+				expectedLiteral string
+			}{
+				{token.STRING, "\\"},
+				{token.EOF, ""},
+			},
+		},
+		{
 			name:  "char",
 			input: `'a'`,
 			expected: []struct {


### PR DESCRIPTION
## Summary
- handle escaped newlines, quotes, and backslashes while lexing string literals
- cover the new escape handling with lexer tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d98ff7e94c832ebc58172fdf812b70